### PR TITLE
Add macOS ARM build pipeline

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,68 @@
+name: Build
+
+on:
+  push:
+    tags: ['v*']
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: macos-15
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: '16.0'
+
+      - name: Stamp version from tag
+        if: startsWith(github.ref, 'refs/tags/')
+        run: |
+          TAG="${GITHUB_REF#refs/tags/}"
+          VERSION="${TAG#v}"
+          xcrun agvtool new-marketing-version "$VERSION"
+
+      - name: Build
+        run: |
+          xcodebuild -project Wamp.xcodeproj \
+            -scheme Wamp \
+            -configuration Release \
+            -destination 'platform=macOS,arch=arm64' \
+            -derivedDataPath .build/DerivedData \
+            CODE_SIGN_IDENTITY="" \
+            CODE_SIGNING_REQUIRED=NO \
+            build
+
+      - name: Read version
+        id: version
+        run: |
+          V=$(xcodebuild -project Wamp.xcodeproj -showBuildSettings -json 2>/dev/null \
+            | python3 -c "import sys,json; print(json.load(sys.stdin)[0]['buildSettings']['MARKETING_VERSION'])")
+          echo "version=$V" >> $GITHUB_OUTPUT
+          echo "version=$V"
+
+      - name: Package DMG
+        if: startsWith(github.ref, 'refs/tags/')
+        run: ./scripts/create-dmg.sh "${{ steps.version.outputs.version }}"
+
+      - name: Upload artifact
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: actions/upload-artifact@v4
+        with:
+          name: Wamp-${{ steps.version.outputs.version }}-macOS-arm64.dmg
+          path: release/Wamp-${{ steps.version.outputs.version }}-macOS-arm64.dmg
+          retention-days: 30
+
+      - name: Create release
+        if: startsWith(github.ref, 'refs/tags/')
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="${GITHUB_REF#refs/tags/}"
+          gh release create "$TAG" \
+            --title "Wamp $TAG" \
+            --notes "Release $TAG" \
+            "release/Wamp-${{ steps.version.outputs.version }}-macOS-arm64.dmg"


### PR DESCRIPTION
Adds a GitHub Actions workflow that builds Wamp on macOS 15 / Xcode 16 for ARM64, runs on every push to main and every pull request, and packages a DMG + creates a GitHub release when a tag matching v* is pushed.

Closes #1